### PR TITLE
changing mktemp to mkstemp in rgfref.c

### DIFF
--- a/rgfref.c
+++ b/rgfref.c
@@ -196,12 +196,16 @@ static char *gli_suffix_for_usage(glui32 usage)
 
 frefid_t glk_fileref_create_temp(glui32 usage, glui32 rock)
 {
-    char filename[BUFLEN];
+    char filename[] = "/tmp/glktempfref-XXXXXX";
     fileref_t *fref;
     
-    sprintf(filename, "/tmp/glktempfref-XXXXXX");
-    mktemp(filename);
-    
+    /* This is a pretty good way to do this on Unix systems. It doesn't
+       make sense on Windows, but anybody compiling this library on
+       Windows has already set up some kind of Unix-like environment,
+       I hope. */
+        
+    mkstemp(filename);
+
     fref = gli_new_fileref(filename, usage, rock);
     if (!fref) {
         gli_strict_warning("fileref_create_temp: unable to create fileref.");


### PR DESCRIPTION
This is just the same change from the deprecated mktemp to mkstemp that was made to glkterm.