### PR TITLE
Add stddef to make sure size_t is defined

### DIFF
--- a/glkstart.c
+++ b/glkstart.c
@@ -10,6 +10,7 @@
     *not* be compiled into the Glk library itself.
 */
 
+#include "stddef.h"
 #include "glk.h"
 #include "glkstart.h"
 


### PR DESCRIPTION
As discussed [here](https://github.com/cspiegel/terps/issues/13#issuecomment-1050443612) when compiling advsys interpreter, it will fail because it doesn't recognize `size_t` in glkstart.h

Fixes #44 