### PR TITLE
Use doubles for metrics and window sizes

### DIFF
--- a/remglk.h
+++ b/remglk.h
@@ -36,8 +36,8 @@
 /* Some useful type declarations. */
 
 typedef struct grect_struct {
-    int left, top;
-    int right, bottom;
+    double left, top;
+    double right, bottom;
 } grect_t;
 
 #define grect_set_from_size(boxref, wid, hgt)   \

--- a/rgauto.c
+++ b/rgauto.c
@@ -217,7 +217,7 @@ static void window_state_print(FILE *fl, winid_t win)
         if (dwin->child2)
             fprintf(fl, ",\n\"pair_child2tag\":%ld", (long)dwin->child2->updatetag);
 
-        fprintf(fl, ",\n\"pair_splitpos\":%d", dwin->splitpos);
+        fprintf(fl, ",\n\"pair_splitpos\":%d", (int) dwin->splitpos);
         fprintf(fl, ",\n\"pair_splitwidth\":%d", dwin->splitwidth);
 
         fprintf(fl, ",\n\"pair_dir\":%ld", (long)dwin->dir);
@@ -235,7 +235,7 @@ static void window_state_print(FILE *fl, winid_t win)
         
     case wintype_TextBuffer: {
         window_textbuffer_t *dwin = win->data;
-        fprintf(fl, ",\n\"buf_width\":%d, \"buf_height\":%d", dwin->width, dwin->height);
+        fprintf(fl, ",\n\"buf_width\":%.1f, \"buf_height\":%.1f", dwin->width, dwin->height);
         
         /* We don't save the updatemark/startclear. */
         
@@ -779,7 +779,7 @@ static int window_state_parse(glkunix_library_state_t state, glkunix_unserialize
             dwin->key = libstate_window_find_by_updatetag(state, tag);
         }
         
-        glkunix_unserialize_int(entry, "pair_splitpos", &dwin->splitpos);
+        glkunix_unserialize_int(entry, "pair_splitpos", (int*) &dwin->splitpos);
         glkunix_unserialize_int(entry, "pair_splitwidth", &dwin->splitwidth);
         glkunix_unserialize_uint32(entry, "pair_dir", &dwin->dir);
         glkunix_unserialize_int(entry, "pair_vertical", &dwin->vertical);
@@ -794,8 +794,8 @@ static int window_state_parse(glkunix_library_state_t state, glkunix_unserialize
         window_textbuffer_t *dwin = win_textbuffer_create(win);
         win->data = dwin;
 
-        glkunix_unserialize_int(entry, "buf_width", &dwin->width);
-        glkunix_unserialize_int(entry, "buf_height", &dwin->height);
+        glkunix_unserialize_int(entry, "buf_width", (int*) &dwin->width);
+        glkunix_unserialize_int(entry, "buf_height", (int*) &dwin->height);
 
         glui32 *buf;
         long bufcount;

--- a/rgdata.c
+++ b/rgdata.c
@@ -881,11 +881,11 @@ data_metrics_t *data_metrics_parse(data_raw_t *rawdata)
     dat = data_raw_struct_field(rawdata, "width");
     if (!dat)
         gli_fatal_error("data: Metrics require width");
-    metrics->width = data_raw_int_value(dat);
+    metrics->width = data_raw_real_value(dat);
     dat = data_raw_struct_field(rawdata, "height");
     if (!dat)
         gli_fatal_error("data: Metrics require height");
-    metrics->height = data_raw_int_value(dat);
+    metrics->height = data_raw_real_value(dat);
 
     /* charwidth/charheight aren't spec, but we accept them as a shortcut.
        (Don't send both charwidth and gridcharwidth, e.g., because the
@@ -918,7 +918,7 @@ data_metrics_t *data_metrics_parse(data_raw_t *rawdata)
 
     dat = data_raw_struct_field(rawdata, "margin");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->gridmarginx = val;
         metrics->gridmarginy = val;
         metrics->buffermarginx = val;
@@ -929,28 +929,28 @@ data_metrics_t *data_metrics_parse(data_raw_t *rawdata)
 
     dat = data_raw_struct_field(rawdata, "gridmargin");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->gridmarginx = val;
         metrics->gridmarginy = val;
     }
 
     dat = data_raw_struct_field(rawdata, "buffermargin");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->buffermarginx = val;
         metrics->buffermarginy = val;
     }
 
     dat = data_raw_struct_field(rawdata, "graphicsmargin");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->graphicsmarginx = val;
         metrics->graphicsmarginy = val;
     }
 
     dat = data_raw_struct_field(rawdata, "marginx");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->gridmarginx = val;
         metrics->buffermarginx = val;
         metrics->graphicsmarginx = val;
@@ -958,7 +958,7 @@ data_metrics_t *data_metrics_parse(data_raw_t *rawdata)
 
     dat = data_raw_struct_field(rawdata, "marginy");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->gridmarginy = val;
         metrics->buffermarginy = val;
         metrics->graphicsmarginy = val;
@@ -966,26 +966,26 @@ data_metrics_t *data_metrics_parse(data_raw_t *rawdata)
 
     dat = data_raw_struct_field(rawdata, "gridmarginx");
     if (dat) 
-        metrics->gridmarginx = data_raw_int_value(dat);
+        metrics->gridmarginx = data_raw_real_value(dat);
     dat = data_raw_struct_field(rawdata, "gridmarginy");
     if (dat) 
-        metrics->gridmarginy = data_raw_int_value(dat);
+        metrics->gridmarginy = data_raw_real_value(dat);
     dat = data_raw_struct_field(rawdata, "buffermarginx");
     if (dat) 
-        metrics->buffermarginx = data_raw_int_value(dat);
+        metrics->buffermarginx = data_raw_real_value(dat);
     dat = data_raw_struct_field(rawdata, "buffermarginy");
     if (dat) 
-        metrics->buffermarginy = data_raw_int_value(dat);
+        metrics->buffermarginy = data_raw_real_value(dat);
     dat = data_raw_struct_field(rawdata, "graphicsmarginx");
     if (dat) 
-        metrics->graphicsmarginx = data_raw_int_value(dat);
+        metrics->graphicsmarginx = data_raw_real_value(dat);
     dat = data_raw_struct_field(rawdata, "graphicsmarginy");
     if (dat) 
-        metrics->graphicsmarginy = data_raw_int_value(dat);
+        metrics->graphicsmarginy = data_raw_real_value(dat);
 
     dat = data_raw_struct_field(rawdata, "spacing");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->inspacingx = val;
         metrics->inspacingy = val;
         metrics->outspacingx = val;
@@ -994,44 +994,44 @@ data_metrics_t *data_metrics_parse(data_raw_t *rawdata)
 
     dat = data_raw_struct_field(rawdata, "inspacing");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->inspacingx = val;
         metrics->inspacingy = val;
     }
 
     dat = data_raw_struct_field(rawdata, "outspacing");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->outspacingx = val;
         metrics->outspacingy = val;
     }
 
     dat = data_raw_struct_field(rawdata, "spacingx");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->inspacingx = val;
         metrics->outspacingx = val;
     }
 
     dat = data_raw_struct_field(rawdata, "spacingy");
     if (dat) {
-        glsi32 val = data_raw_int_value(dat);
+        double val = data_raw_real_value(dat);
         metrics->inspacingy = val;
         metrics->outspacingy = val;
     }
 
     dat = data_raw_struct_field(rawdata, "inspacingx");
     if (dat)
-        metrics->inspacingx = data_raw_int_value(dat);
+        metrics->inspacingx = data_raw_real_value(dat);
     dat = data_raw_struct_field(rawdata, "inspacingy");
     if (dat)
-        metrics->inspacingy = data_raw_int_value(dat);
+        metrics->inspacingy = data_raw_real_value(dat);
     dat = data_raw_struct_field(rawdata, "outspacingx");
     if (dat)
-        metrics->outspacingx = data_raw_int_value(dat);
+        metrics->outspacingx = data_raw_real_value(dat);
     dat = data_raw_struct_field(rawdata, "outspacingy");
     if (dat)
-        metrics->outspacingy = data_raw_int_value(dat);
+        metrics->outspacingy = data_raw_real_value(dat);
 
     if (metrics->gridcharwidth <= 0 || metrics->gridcharheight <= 0
         || metrics->buffercharwidth <= 0 || metrics->buffercharheight <= 0)
@@ -1043,14 +1043,14 @@ data_metrics_t *data_metrics_parse(data_raw_t *rawdata)
 void data_metrics_print(FILE *fl, data_metrics_t *metrics)
 {
     fprintf(fl, "{\n");   
-    fprintf(fl, "  \"width\": %ld, \"height\": %ld,\n", (long)metrics->width, (long)metrics->height);
-    fprintf(fl, "  \"outspacingx\": %ld, \"outspacingy\": %ld,\n", (long)metrics->outspacingx, (long)metrics->outspacingy);
-    fprintf(fl, "  \"inspacingx\": %ld, \"inspacingy\": %ld,\n", (long)metrics->inspacingx, (long)metrics->inspacingy);
+    fprintf(fl, "  \"width\": %.1f, \"height\": %.1f,\n", metrics->width, metrics->height);
+    fprintf(fl, "  \"outspacingx\": %.1f, \"outspacingy\": %.1f,\n", metrics->outspacingx, metrics->outspacingy);
+    fprintf(fl, "  \"inspacingx\": %.1f, \"inspacingy\": %.1f,\n", metrics->inspacingx, metrics->inspacingy);
     fprintf(fl, "  \"gridcharwidth\": %.1f, \"gridcharheight\": %.1f,\n", metrics->gridcharwidth, metrics->gridcharheight);
-    fprintf(fl, "  \"gridmarginx\": %ld, \"gridmarginy\": %ld,\n", (long)metrics->gridmarginx, (long)metrics->gridmarginy);
+    fprintf(fl, "  \"gridmarginx\": %.1f, \"gridmarginy\": %.1f,\n", metrics->gridmarginx, metrics->gridmarginy);
     fprintf(fl, "  \"buffercharwidth\": %.1f, \"buffercharheight\": %.1f,\n", metrics->buffercharwidth, metrics->buffercharheight);
-    fprintf(fl, "  \"buffermarginx\": %ld, \"buffermarginy\": %ld,\n", (long)metrics->buffermarginx, (long)metrics->buffermarginy);
-    fprintf(fl, "  \"graphicsmarginx\": %ld, \"graphicsmarginy\": %ld\n", (long)metrics->graphicsmarginx, (long)metrics->graphicsmarginy);
+    fprintf(fl, "  \"buffermarginx\": %.1f, \"buffermarginy\": %.1f,\n", metrics->buffermarginx, metrics->buffermarginy);
+    fprintf(fl, "  \"graphicsmarginx\": %.1f, \"graphicsmarginy\": %.1f\n", metrics->graphicsmarginx, metrics->graphicsmarginy);
     fprintf(fl, "}\n");   
 }
 
@@ -1568,7 +1568,7 @@ void data_window_print(data_window_t *dat)
         printf("   \"gridwidth\":%d, \"gridheight\":%d,\n", dat->gridwidth, dat->gridheight);
     if (dat->type == wintype_Graphics)
         printf("   \"graphwidth\":%d, \"graphheight\":%d,\n", dat->gridwidth, dat->gridheight);
-    printf("   \"left\":%d, \"top\":%d, \"width\":%d, \"height\":%d }",
+    printf("   \"left\":%.1f, \"top\":%.1f, \"width\":%.1f, \"height\":%.1f }",
         dat->size.left, dat->size.top, dat->size.right-dat->size.left, dat->size.bottom-dat->size.top);
 }
 
@@ -2187,7 +2187,7 @@ void data_grect_clear(grect_t *box)
 
 void data_grect_print(FILE *file, grect_t *box)
 {
-    fprintf(file, "{\"left\":%d, \"top\":%d, \"right\":%d, \"bottom\":%d}",
+    fprintf(file, "{\"left\":%.1f, \"top\":%.1f, \"right\":%.1f, \"bottom\":%.1f}",
         box->left, box->top, box->right, box->bottom);
 }
 

--- a/rgdata.h
+++ b/rgdata.h
@@ -49,14 +49,14 @@ typedef struct data_specialspan_struct data_specialspan_t;
 
 /* data_metrics_t: Defines the display metrics. */
 struct data_metrics_struct {
-    glui32 width, height;
-    glui32 outspacingx, outspacingy;
-    glui32 inspacingx, inspacingy;
+    double width, height;
+    double outspacingx, outspacingy;
+    double inspacingx, inspacingy;
     double gridcharwidth, gridcharheight;
-    glui32 gridmarginx, gridmarginy;
+    double gridmarginx, gridmarginy;
     double buffercharwidth, buffercharheight;
-    glui32 buffermarginx, buffermarginy;
-    glui32 graphicsmarginx, graphicsmarginy;
+    double buffermarginx, buffermarginy;
+    double graphicsmarginx, graphicsmarginy;
 };
 
 /* data_supportcaps_t: List of I/O capabilities of the client. */

--- a/rgwin_buf.c
+++ b/rgwin_buf.c
@@ -101,12 +101,12 @@ void win_textbuffer_destroy(window_textbuffer_t *dwin)
 
 void win_textbuffer_rearrange(window_t *win, grect_t *box, data_metrics_t *metrics)
 {
-    int oldwid, oldhgt;
+    //int oldwid, oldhgt;
     window_textbuffer_t *dwin = win->data;
     dwin->owner->bbox = *box;
 
-    oldwid = dwin->width;
-    oldhgt = dwin->height;
+    //oldwid = dwin->width;
+    //oldhgt = dwin->height;
 
     dwin->width = box->right - box->left;
     dwin->height = box->bottom - box->top;

--- a/rgwin_buf.h
+++ b/rgwin_buf.h
@@ -23,7 +23,7 @@ typedef struct window_textbuffer_struct {
     long numspecials;
     long specialssize;
     
-    int width, height;
+    double width, height;
     
     long updatemark;
     int startclear;

--- a/rgwin_graph.c
+++ b/rgwin_graph.c
@@ -94,13 +94,13 @@ void win_graphics_rearrange(window_t *win, grect_t *box, data_metrics_t *metrics
     window_graphics_t *dwin = win->data;
     dwin->owner->bbox = *box;
 
-    int width = box->right - box->left;
-    int height = box->bottom - box->top;
+    double width = box->right - box->left;
+    double height = box->bottom - box->top;
 
-    dwin->graphwidth = width - metrics->graphicsmarginx;
+    dwin->graphwidth = (int) (width - metrics->graphicsmarginx);
     if (dwin->graphwidth < 0)
         dwin->graphwidth = 0;
-    dwin->graphheight = height - metrics->graphicsmarginy;
+    dwin->graphheight = (int) (height - metrics->graphicsmarginy);
     if (dwin->graphheight < 0)
         dwin->graphheight = 0;
 }

--- a/rgwin_grid.c
+++ b/rgwin_grid.c
@@ -88,8 +88,8 @@ void win_textgrid_rearrange(window_t *win, grect_t *box, data_metrics_t *metrics
     window_textgrid_t *dwin = win->data;
     dwin->owner->bbox = *box;
     
-    newwid = (((box->right - box->left) - metrics->gridmarginx) / metrics->gridcharwidth);
-    newhgt = (((box->bottom - box->top) - metrics->gridmarginy) / metrics->gridcharheight);
+    newwid = (int)(((box->right - box->left) - metrics->gridmarginx) / metrics->gridcharwidth);
+    newhgt = (int)(((box->bottom - box->top) - metrics->gridmarginy) / metrics->gridcharheight);
     
     if (dwin->lines == NULL) {
         dwin->linessize = (newhgt+1);

--- a/rgwin_pair.c
+++ b/rgwin_pair.c
@@ -48,7 +48,7 @@ void win_pair_rearrange(window_t *win, grect_t *box, data_metrics_t *metrics)
 {
     window_pair_t *dwin = win->data;
     grect_t box1, box2;
-    int min, diff, split, splitwid, max;
+    double min, diff, split, splitwid, max;
     window_t *key;
     window_t *ch1, *ch2;
 
@@ -135,7 +135,7 @@ void win_pair_rearrange(window_t *win, grect_t *box, data_metrics_t *metrics)
 
     if (dwin->vertical) {
         dwin->splitpos = split;
-        dwin->splitwidth = splitwid;
+        dwin->splitwidth = (int) splitwid;
         box1.left = win->bbox.left;
         box1.right = dwin->splitpos;
         box2.left = box1.right + dwin->splitwidth;
@@ -155,7 +155,7 @@ void win_pair_rearrange(window_t *win, grect_t *box, data_metrics_t *metrics)
     }
     else {
         dwin->splitpos = split;
-        dwin->splitwidth = splitwid;
+        dwin->splitwidth = (int) splitwid;
         box1.top = win->bbox.top;
         box1.bottom = dwin->splitpos;
         box2.top = box1.bottom + dwin->splitwidth;

--- a/rgwin_pair.h
+++ b/rgwin_pair.h
@@ -8,7 +8,7 @@ typedef struct window_pair_struct {
     window_t *owner;
 
     window_t *child1, *child2; 
-    int splitpos; /* The split center. To be picky, this is the position
+    double splitpos; /* The split center. To be picky, this is the position
         of the top of the border, or the top of the bottom window if the
         border is zero-width. (If vertical is true, rotate this comment
         90 degrees.) */

--- a/rgwindow.c
+++ b/rgwindow.c
@@ -867,7 +867,8 @@ void glk_window_get_size(window_t *win, glui32 *width, glui32 *height)
 {
     glui32 wid = 0;
     glui32 hgt = 0;
-    int val, boxwidth, boxheight;
+    int val;
+    double boxwidth, boxheight;
     
     if (!win) {
         gli_strict_warning("window_get_size: invalid ref");
@@ -882,24 +883,24 @@ void glk_window_get_size(window_t *win, glui32 *width, glui32 *height)
         case wintype_TextGrid:
             boxwidth = win->bbox.right - win->bbox.left;
             boxheight = win->bbox.bottom - win->bbox.top;
-            val = floor((boxwidth-metrics.gridmarginx) / metrics.gridcharwidth);
+            val = (int) floor((boxwidth-metrics.gridmarginx) / metrics.gridcharwidth);
             wid = ((val >= 0) ? val : 0);
-            val = floor((boxheight-metrics.gridmarginy) / metrics.gridcharheight);
+            val = (int) floor((boxheight-metrics.gridmarginy) / metrics.gridcharheight);
             hgt = ((val >= 0) ? val : 0);
             break;
         case wintype_TextBuffer:
             boxwidth = win->bbox.right - win->bbox.left;
             boxheight = win->bbox.bottom - win->bbox.top;
-            val = floor((boxwidth-metrics.buffermarginx) / metrics.buffercharwidth);
+            val = (int) floor((boxwidth-metrics.buffermarginx) / metrics.buffercharwidth);
             wid = ((val >= 0) ? val : 0);
-            val = floor((boxheight-metrics.buffermarginy) / metrics.buffercharheight);
+            val = (int) floor((boxheight-metrics.buffermarginy) / metrics.buffercharheight);
             hgt = ((val >= 0) ? val : 0);
             break;
         case wintype_Graphics:
             boxwidth = win->bbox.right - win->bbox.left;
             boxheight = win->bbox.bottom - win->bbox.top;
-            wid = boxwidth - metrics.graphicsmarginx;
-            hgt = boxheight - metrics.graphicsmarginy;
+            wid = (int) (boxwidth - metrics.graphicsmarginx);
+            hgt = (int) (boxheight - metrics.graphicsmarginy);
             break;
     }
 


### PR DESCRIPTION
Hopefully this is a more thorough and reliable solution to https://github.com/erkyrath/lectrote/issues/133

I've confirmed that it does fix the issue with the TADS 3 status windows (using AsyncGlk, not GlkOte), but there are probably still some bugs. I'm not very familiar with the code.

The autosave code uses ints though, as there weren't functions for serializing doubles.